### PR TITLE
Clarification of WebAssembly.Function instances

### DIFF
--- a/proposals/js-types/Overview.md
+++ b/proposals/js-types/Overview.md
@@ -161,6 +161,8 @@ Concretely, the change is the following:
 
 * All exported functions are of class `WebAssembly.Function`.
 
+* Functions constructed by `WebAssembly.Function` behave no different from other exported functions taken from a module's exports. More specifically, they have a [[FunctionAddress]] internal slot which identifies them as exported functions.
+
 
 ## Example
 


### PR DESCRIPTION
This adds a note about the intended behavior of functions constructed via WebAssembly.Function to the proposal, clarifying that they do have a [[FunctionAddress]] internal slot.