### PR TITLE
Remove left-over test expectation

### DIFF
--- a/test/js-api/module/imports.any.js
+++ b/test/js-api/module/imports.any.js
@@ -169,7 +169,6 @@ test(() => {
       "name": "fn",
       "type": {"parameters": [], "results": []}
     },
-    { "module": "", "kind": "function", "name": "fn" },
     { "module": "", "kind": "global", "name": "global", "value": "i32" },
     { "module": "", "kind": "memory", "name": "memory" },
     { "module": "", "kind": "table", "name": "table" },


### PR DESCRIPTION
A test expectation in `imports.any.js` got updated, but the old version did not get deleted.