### PR TITLE
Fix `min` and `max` to `minimum` and `maximum` in the overview

### DIFF
--- a/proposals/js-types/Overview.md
+++ b/proposals/js-types/Overview.md
@@ -36,7 +36,7 @@ type ValueType = "i32" | "i64" | "f32" | "f64" | "v128" | RefType
 type GlobalType = {value: ValueType, mutable: boolean}
 type MemoryType = {limits: Limits}
 type TableType = {limits: Limits, element: RefType}
-type Limits = {min: number, max?: number}  // see below
+type Limits = {minimum: number, maximum?: number}  // see below
 type FunctionType = {parameters: ValueType[], results: ValueType[]}
 type ExternType =
   {kind: "function", type: FunctionType} |


### PR DESCRIPTION
According to the spec[^1], the properties representing the limits are named `minimum` and `maximum`. However, in the overview[^2] of this repository, `min` and `max` are used.

This PR updates the property names in the overview.

[^1]: https://webassembly.github.io/js-types/js-api/index.html#dictdef-anyexterntype
[^2]: https://github.com/WebAssembly/js-types/blob/eec73e1e5ea7471e6f9e89bb2e92dc5e5b3bc93d/proposals/js-types/Overview.md